### PR TITLE
[CI-CD] Add Maven publishing and refactor CI scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# Git files
+.idea

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,13 +5,14 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
-name: Java CI with Gradle
+name: Authorization Server CI/CD
 
 env:
   GIT_USERNAME: ${{ secrets.GIT_USERNAME }}
   GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+
 on:
   push:
     branches: [ "main" ]
@@ -75,7 +76,7 @@ jobs:
           path: build/reports/tests/intTest/
 
   publish-artifact:
-    needs: [ build, integration-test]
+#    needs: [ build, integration-test]
 #    if: github.ref == 'refs/heads/ci-cd-practices/publish'
 #    if: github.event.pull_request.head.ref == 'ci-cd-practices/publish'
     runs-on: ubuntu-latest
@@ -89,9 +90,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-#          cache: gradle
-          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          settings-path: ${{ github.workspace }} # location for the settings.xml file
+          cache: gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
 
@@ -100,9 +99,6 @@ jobs:
 
       # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
       # the publishing section of your build.gradle
-      - name: Values check
-        run: |
-          echo "Registry: ${{ env.GIT_USERNAME }}"
       - name: Publish to GitHub Packages
         run: ./gradlew publish
 
@@ -113,12 +109,12 @@ jobs:
       contents: read
       packages: write
     steps:
-    - name: check values
-      run: |
-        echo "User: ${{ github.actor }}"
-        echo "Image Name (env): ${{ env.IMAGE_NAME }}"
     - name: Checkout repository
       uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Log in to the Container registry
       uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
       with:
@@ -126,30 +122,17 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ env.GIT_TOKEN  }}
 
-    - name: Set up JDK 21
-      uses: actions/setup-java@v4
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-#        cache: gradle
-        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-        settings-path: ${{ github.workspace }} # location for the settings.xml file
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
-
     - name: Extract metadata (tags, labels) for Docker
       id: meta
       uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-    - name: Build with Gradle
-      run: ./gradlew build
-
     - name: Build and push Docker image
       uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
       with:
         context: .
+        push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
 
@@ -166,8 +149,6 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          settings-path: ${{ github.workspace }} # location for the settings.xml file
       # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
       # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
       - name: Generate and submit dependency graph

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,18 +5,18 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
-name: Authorization Server CI/CD
-
-env:
-  GIT_USERNAME: ${{ secrets.GIT_USERNAME }}
-  GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+name: Authorization Server CI
 
 on:
   push:
     branches: [ "main" ]
   pull_request:
+
+env:
+  GIT_USERNAME: ${{ github.actor }}
+  GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '21'
-          distribution: 'temurin'
+          distribution: 'corretto'
           cache: gradle
       # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
       # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
@@ -63,7 +63,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '21'
-          distribution: 'temurin'
+          distribution: 'corretto'
           cache: gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -76,65 +76,68 @@ jobs:
           path: build/reports/tests/intTest/
 
   publish-artifact:
-#    needs: [ build, integration-test]
-#    if: github.ref == 'refs/heads/ci-cd-practices/publish'
-#    if: github.event.pull_request.head.ref == 'ci-cd-practices/publish'
+    if: github.ref == 'refs/heads/main'
+    needs: [build, integration-test]
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: '21'
-          distribution: 'temurin'
+          distribution: 'corretto'
           cache: gradle
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
 
-      - name: Build with Gradle
-        run: ./gradlew build
-
-      # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
-      # the publishing section of your build.gradle
       - name: Publish to GitHub Packages
-        run: ./gradlew publish
+        run: ./gradlew build publish
 
   build-and-push-image:
-    needs: [ publish-artifact]
+    needs: publish-artifact
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read
       packages: write
+      #
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-    - name: Log in to the Container registry
-      uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ env.GIT_TOKEN  }}
-
-    - name: Extract metadata (tags, labels) for Docker
-      id: meta
-      uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-      with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
-      with:
-        context: .
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.GIT_USERNAME }}
+          password: ${{ env.GIT_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
 
   dependency-submission:
@@ -148,7 +151,8 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '21'
-          distribution: 'temurin'
+          distribution: 'corretto'
+          cache: gradle
       # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
       # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
       - name: Generate and submit dependency graph

--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -7,6 +7,11 @@
 
 name: Java CI with Gradle
 
+env:
+  GIT_USERNAME: ${{ secrets.GIT_USERNAME }}
+  GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 on:
   push:
     branches: [ "main" ]
@@ -14,11 +19,9 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
-
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21
@@ -26,15 +29,13 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-
+          cache: gradle
       # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
       # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-
       - name: Build with Gradle Wrapper
         run: ./gradlew build
-
       - name: Upload test result artifacts
         uses:  actions/upload-artifact@v4
         with:
@@ -62,24 +63,25 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+          cache: gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-
       - name: Integration Test with Gradle Wrapper
         run: ./gradlew intTest
-
       - name: Upload integration test result artifacts
         uses: actions/upload-artifact@v4
         with:
           name: integration-tests
           path: build/reports/tests/intTest/
 
-  dependency-submission:
-
+  publish-artifact:
+    needs: [ build, integration-test]
+#    if: github.ref == 'refs/heads/ci-cd-practices/publish'
+#    if: github.event.pull_request.head.ref == 'ci-cd-practices/publish'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21
@@ -87,7 +89,85 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+#          cache: gradle
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
 
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
+      # the publishing section of your build.gradle
+      - name: Values check
+        run: |
+          echo "Registry: ${{ env.GIT_USERNAME }}"
+      - name: Publish to GitHub Packages
+        run: ./gradlew publish
+
+  build-and-push-image:
+    needs: [ publish-artifact]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: check values
+      run: |
+        echo "User: ${{ github.actor }}"
+        echo "Image Name (env): ${{ env.IMAGE_NAME }}"
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Log in to the Container registry
+      uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ env.GIT_TOKEN  }}
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+#        cache: gradle
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+    - name: Build with Gradle
+      run: ./gradlew build
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+      with:
+        context: .
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+
+
+  dependency-submission:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
       # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
       # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
       - name: Generate and submit dependency graph

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 /src/main/resources/private-pkcs8.pem
 /src/main/resources/public.pem
 /test.env
+/scripts/local.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,25 @@
 # syntax=docker/dockerfile:experimental
-FROM eclipse-temurin:21-jdk-alpine AS build
-RUN pwd
-COPY . /workspace/app
+FROM amazoncorretto:21-alpine-jdk AS build
+
+LABEL org.opencontainers.image.source https://github.com/rbautisf/spring-auth-server
+
 WORKDIR /workspace/app
-RUN pwd
-# print the current directory in the log
-RUN chmod +x ./gradlew && ls -la
+COPY . /workspace/app
+
 RUN --mount=type=cache,target=/root/.gradle ./gradlew clean build
 RUN mkdir -p build/dependency && (cd build/dependency; jar -xf ../libs/*-SNAPSHOT.jar)
 
-# Fetch runtime JDK for the new building stage
-FROM eclipse-temurin:21-jre-alpine
-# Create user and group
+FROM amazoncorretto:21-alpine-jdk AS runtime
+
 RUN addgroup -S spring && adduser -S spring -G spring
 USER spring
 
-# ARG is used to define build-time variables, 
-# they're not available after the image has been built. DEPENDENCY variable is reused in many places, so it better to declare it once
 VOLUME /tmp
 ARG DEPENDENCY=/workspace/app/build/dependency
 COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib
 COPY --from=build ${DEPENDENCY}/META-INF /app/META-INF
 COPY --from=build ${DEPENDENCY}/BOOT-INF/classes /app
 
-# Expose port
 EXPOSE 9000
 
-# Start your java application
 ENTRYPOINT ["java","-cp","app:app/lib/*","com.nowhere.springauthserver.SpringAuthServerApplication"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,30 @@
-## Docker image for Springboot application gradle
-FROM  amazoncorretto:21-alpine-jdk
-ARG JAR_FILE=build/libs/*-SNAPSHOT.jar
-COPY ${JAR_FILE} app.jar
-#Expose the authorization server port and the db port
-EXPOSE 9000
-ENTRYPOINT ["java","-jar","app.jar"]
+# syntax=docker/dockerfile:experimental
+FROM eclipse-temurin:21-jdk-alpine AS build
+RUN pwd
+COPY . /workspace/app
+WORKDIR /workspace/app
+RUN pwd
+# print the current directory in the log
+RUN chmod +x ./gradlew && ls -la
+RUN --mount=type=cache,target=/root/.gradle ./gradlew clean build
+RUN mkdir -p build/dependency && (cd build/dependency; jar -xf ../libs/*-SNAPSHOT.jar)
 
+# Fetch runtime JDK for the new building stage
+FROM eclipse-temurin:21-jre-alpine
+# Create user and group
+RUN addgroup -S spring && adduser -S spring -G spring
+USER spring
+
+# ARG is used to define build-time variables, 
+# they're not available after the image has been built. DEPENDENCY variable is reused in many places, so it better to declare it once
+VOLUME /tmp
+ARG DEPENDENCY=/workspace/app/build/dependency
+COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib
+COPY --from=build ${DEPENDENCY}/META-INF /app/META-INF
+COPY --from=build ${DEPENDENCY}/BOOT-INF/classes /app
+
+# Expose port
+EXPOSE 9000
+
+# Start your java application
+ENTRYPOINT ["java","-cp","app:app/lib/*","com.nowhere.springauthserver.SpringAuthServerApplication"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Execute the docker-compose file to start the database.
 ```shell
 scripts/docker-compose up
 ```
+Please note that the init.sql file is used to create the database schema and the initial data, if you are using your own database, please make sure to have the schema and data created.  
+
 Optional: Build the docker image and use the image from the docker-compose file to start the application.
 ```shell
 docker build -t auth-nowhere .
@@ -46,7 +48,6 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 REDIS_HOST=
 REDIS_PORT=
-REDIS_PW=
 ```
 ## Key Generation
 #### Creating Private Key

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'java-library' //includes 'java'
     id 'java-test-fixtures'
     id 'jacoco'
+    id 'maven-publish'
 }
 
 group = 'com.nowhere'
@@ -111,4 +112,23 @@ jacocoTestReport {
         }))
     }
     dependsOn (test, intTest)
+}
+
+// https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-gradle-registry#example-using-gradle-groovy-for-a-single-package-in-a-repository
+publishing {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/rbautisf/spring-auth-server")
+            credentials {
+                username = System.getenv("GIT_USERNAME")
+                password = System.getenv("GIT_TOKEN")
+            }
+        }
+    }
+    publications {
+        gpr(MavenPublication) {
+            from(components.java)
+        }
+    }
 }

--- a/scripts/.env
+++ b/scripts/.env
@@ -1,22 +1,24 @@
 # Description: Environment variables for the project
 # Postgres Config
-POSTGRES_USER=
-POSTGRES_PW=
-POSTGRES_DB=
+POSTGRES_USER=postgres
+POSTGRES_PW=nowhere
+POSTGRES_DB=oauth_nowhere
 
 # PGAdmin Config
-PGADMIN_EMAIL=
-PGADMIN_PW=
+PGADMIN_EMAIL=postgres@nowhere.com
+PGADMIN_PW=nowhere
 
 # Authorization Server Config
-PRIVATE_KEY=
+SERVER_PORT=9000
+DATASOURCE_URL=jdbc:postgresql://localhost:5433/oauth_nowhere
+DB_USERNAME=postgres
+DB_PASSWORD=nowhere
 
-PUBLIC_KEY=
-
+PRIVATE_KEY= #REQUIRED
+PUBLIC_KEY= #REQUIRED
 # Github OAuth Config
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
-
 # Google OAuth Config
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -109,7 +109,6 @@ Following are the environment variables used in this configuration:
 - `GOOGLE_CLIENT_SECRET` - This is the client secret provided by Google for OAuth 2.0 Applications. This is used when exchanging the auth code for access tokens.
 - `REDIS_HOST` - This is the host name of the Redis Cache service.
 - `REDIS_PORT` - This is the port number of the Redis Cache service.
-- `REDIS_PW` - This is the password for the Redis Cache service.
 
 
 These values are stored in environment variables to ensure sensitive information is not available in your application code and to allow for easy updating of these values.

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
   #  Uncomment once you have the local image built
   auth-server:
     container_name: authorization-server
-    image: authorization-server:latest
+    image: ghcr.io/rbautisf/spring-auth-server:latest
     environment:
       - DATASOURCE_URL=jdbc:postgresql://postgres:5432/oauth_nowhere
       - DB_USERNAME=${POSTGRES_USER}
@@ -42,7 +42,6 @@ services:
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
       - REDIS_HOST=${REDIS_HOST}
       - REDIS_PORT=${REDIS_PORT}
-      - REDIS_PW=${REDIS_PW}
     ports:
       - "9000:9000"
     restart: always

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'spring-auth-server'
+rootProject.name = 'auth-server'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,7 +9,6 @@ spring:
     redis:
       port: ${REDIS_PORT:6379}
       host: ${REDIS_HOST:localhost}
-      password: ${REDIS_PW:nowhere}
       select-database: 0
   session:
     store-type: redis


### PR DESCRIPTION
Updated the GitHub Actions workflows to enable the 'publish-artifact' and 'build-and-push-image' jobs on the 'main' branch. 